### PR TITLE
bin/recover-broken-vdb-find-broken.sh: check dynamic exes, not just .sos

### DIFF
--- a/bin/recover-broken-vdb-find-broken.sh
+++ b/bin/recover-broken-vdb-find-broken.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Identify packages in the VDB that provide .so files but are missing an
-# expected PROVIDES or NEEDED* file.
+# Identify packages in the VDB that provide executables or .so files,
+# but are missing an expected PROVIDES or NEEDED* file.
 
 die()
 {
@@ -18,20 +18,27 @@ test -n "$vdb_path" || die "Could not determine vdb_path. Cannot continue."
 cd "$vdb_path" || die "Could not chdir vdb_path ($vdb_path). Cannot continue."
 
 for A in */*/CONTENTS ; do
-    # Iterate over all .sos they install
-    for O in $(sed -n -E 's%^obj (/[^ ]+\.so( |\.[^ ]+)).*%\1%p' $A | sed 's/ $//') ; do
-        SHARED=$(file "$O" | egrep 'shared object')
-        # Check if the file is really a shared object
-        if [ -n "$SHARED" ]; then
-            T=$(echo "$A" | cut -d/ -f1,2)
-
-            # If it is, complain if we are missing the expected ELF metadata in the VDB
-            if [ ! -f "${T}/PROVIDES" -o ! -f "${T}/NEEDED" -o ! -f "${T}/NEEDED.ELF.2" ]; then
+    CPV=$(echo "$A" | cut -d/ -f1,2)
+    # Iterate over all potential shared libs or executables they install
+    for O in $(sed -n -E 's%^obj (/.*(\.so( |\.[^ ]+)|bin/[^ ]+)).*%\1%p' $A | sed 's/ $//') ; do
+        # Check if the file is really a shared object or executable
+        F=$(file -b "${O}" 2>/dev/null)
+        test -n "$F" || die "Could not run 'file' on '$O'. Cannot continue."
+        # If it is an executable, check that we have NEEDED* metadata in the VDB
+        if echo "${F}" | egrep -q "ELF .*executable.*dynamically linked" ; then
+            if [ ! -f "${CPV}/NEEDED" -o ! -f "${CPV}/NEEDED.ELF.2" ]; then
                 # Remember this package with full version suitable for re-emerging
-                pkgs+=("=${T}")
+                pkgs+=("=${CPV}")
+                # We know this package is broken, move on to the next
+                break
             fi
-
-            # We checked this package already so we can bail out
+        # If it is a shared library, check that we have NEEDED* and PROVIDES in the VDB
+        elif echo "${F}" | egrep -q "ELF .*shared object" ; then
+            if [ ! -f "${CPV}/PROVIDES" -o ! -f "${CPV}/NEEDED" -o ! -f "${CPV}/NEEDED.ELF.2" ]; then
+                # Remember this package with full version suitable for re-emerging
+                pkgs+=("=${CPV}")
+            fi
+            # We have checked this package thoroughly so we can move on
             break
         fi
     done


### PR DESCRIPTION
We need to check for NEEDED* files any time we find a dynamic
executable, besides checking for NEEDED* and PROVIDES when we find
shared libraries.

Signed-off-by: Hank Leininger <hlein@korelogic.com>